### PR TITLE
[Feat] Add mathajax and latex equation feature to blog

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -14,6 +14,14 @@ module.exports = {
     author: ``
   },
   plugins: [
+{
+    resolve: `gatsby-transformer-remark`,
+    options: {
+      plugins: [
+        `gatsby-remark-mathjax`,
+      ],
+    },
+  },
     {
       resolve: `@lekoarts/gatsby-theme-minimal-blog`,
       options: {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "gatsby-plugin-netlify": "^2.1.3",
     "gatsby-plugin-offline": "^2.2.4",
     "gatsby-plugin-sitemap": "^2.2.19",
+    "gatsby-remark-mathjax": "^1.0.0",
+    "gatsby-remark-mathjax-ssr": "^1.2.1",
+    "gatsby-transformer-remark": "^2.8.27",
     "react": "^16.9.0",
     "react-dom": "^16.9.0"
   },

--- a/src/html.js
+++ b/src/html.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const MathJaxConfig = `
+window.MathJax = {
+  tex2jax: {
+    inlineMath: [['$', '$'] ],
+    displayMath: [['$$', '$$'] ],
+    processEscapes: true,
+    processEnvironments: true,
+    skipTags: ['script', 'noscript', 'style', 'textarea', 'pre'],
+    TeX: {
+      equationNumbers: {autoNumber: 'AMS'},
+      extensions: ['AMSmath.js', 'AMSsymbols.js', 'color.js'],
+    },
+  }
+};
+`;
+
+export default class HTML extends React.Component {
+  render() {
+    return (
+      <html {...this.props.htmlAttributes}>
+        <head>
+          <meta charSet="utf-8" />
+          <meta httpEquiv="x-ua-compatible" content="ie=edge" />
+          <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1, shrink-to-fit=no"
+          />
+          {this.props.headComponents}
+        </head>
+        <body {...this.props.bodyAttributes}>
+          {this.props.preBodyComponents}
+          <div
+            key={`body`}
+            id="___gatsby"
+            dangerouslySetInnerHTML={{__html: this.props.body}}
+          />
+          {this.props.postBodyComponents}
+          <script dangerouslySetInnerHTML={{__html: MathJaxConfig}} />
+          <script
+            defer
+            src="https://cdn.bootcss.com/mathjax/2.7.4/latest.js?config=TeX-AMS_SVG"
+          />
+        </body>
+      </html>
+    );
+  }
+}
+
+HTML.propTypes = {
+  htmlAttributes: PropTypes.object,
+  headComponents: PropTypes.array,
+  bodyAttributes: PropTypes.object,
+  preBodyComponents: PropTypes.array,
+  body: PropTypes.string,
+  postBodyComponents: PropTypes.array,
+};


### PR DESCRIPTION
This allows us to add latex equations to blog and render them using mathjax.
Following the process from [here](https://www.gatsbyjs.org/packages/gatsby-remark-mathjax/) and [here](https://zhoumingjun.github.io/post/2018-09-04-enable-mathjax-in-gatsby/)